### PR TITLE
Battery compensation on motor output

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -64,6 +64,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .vbat_comp_ref = 37,
             .vbat_comp_throttle_level = 75,
             .vbat_comp_pid_level = 75,
+            .vbat_comp_motor_output = 0
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -62,6 +62,7 @@ typedef struct controlRateConfig_s {
     uint8_t vbat_comp_ref;                  // Sets the voltage reference to calculate the battery compensation
     uint8_t vbat_comp_throttle_level;       // Sets the level of throttle battery compensation
     uint8_t vbat_comp_pid_level;            // Sets the level of PID battery compensation
+    uint8_t vbat_comp_motor_output;         // Tells whether the battery compensation has to be applied to motor output or not
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -978,6 +978,7 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentControlRateProfile->vbat_comp_ref);
         sbufWriteU8(dst, currentControlRateProfile->vbat_comp_throttle_level);
         sbufWriteU8(dst, currentControlRateProfile->vbat_comp_pid_level);
+        sbufWriteU8(dst, currentControlRateProfile->vbat_comp_motor_output);
 
         break;
 
@@ -1766,11 +1767,12 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 currentControlRateProfile->throttle_limit_type = sbufReadU8(src);
                 currentControlRateProfile->throttle_limit_percent = sbufReadU8(src);
             }
-            if (sbufBytesRemaining(src) >= 4) {
+            if (sbufBytesRemaining(src) >= 5) {
                 currentControlRateProfile->vbat_comp_type = sbufReadU8(src);
                 currentControlRateProfile->vbat_comp_ref = sbufReadU8(src);
                 currentControlRateProfile->vbat_comp_throttle_level = sbufReadU8(src);
                 currentControlRateProfile->vbat_comp_pid_level = sbufReadU8(src);
+                currentControlRateProfile->vbat_comp_motor_output = sbufReadU8(src);
             }
             initRcProcessing();
         } else {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -766,6 +766,7 @@ const clivalue_t valueTable[] = {
     { "vbat_comp_ref"         ,     VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { VBAT_CELL_VOTAGE_RANGE_MIN, VBAT_CELL_VOTAGE_RANGE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_ref) },
     { "vbat_comp_throttle_level",   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_throttle_level) },
     { "vbat_comp_pid_level",        VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_pid_level) },
+    { "vbat_comp_motor_output",     VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_motor_output) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -461,7 +461,7 @@ void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
 float calculateVbatCompensation(uint8_t vbatCompType, uint8_t vbatCompRef)
 {
     float factor =  1.0f;
-    if (vbatCompType != VBAT_COMP_TYPE_OFF && batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
+    if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
         float vbat = (float) voltageMeter.filtered / batteryCellCount;
         if (vbat) {
             factor = vbatCompRef / vbat;
@@ -477,6 +477,12 @@ float calculateVbatCompensation(uint8_t vbatCompType, uint8_t vbatCompRef)
         }
     }
     return factor;
+}
+
+float applyVbatCompensation(float value, uint8_t compensationLevel)
+{
+    float vbatCompensation = calculateVbatCompensation(currentControlRateProfile->vbat_comp_type, currentControlRateProfile->vbat_comp_ref);
+    return value * scaleRangef(compensationLevel, 0, 100, 1.0f, vbatCompensation);
 }
 
 uint8_t calculateBatteryPercentageRemaining(void)

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -97,7 +97,7 @@ void batteryUpdateAlarms(void);
 
 struct rxConfig_s;
 
-float calculateVbatCompensation(uint8_t vbatCompType, uint8_t vbatCompRef);
+float applyVbatCompensation(float value, uint8_t compensationLevel);
 uint8_t calculateBatteryPercentageRemaining(void);
 bool isBatteryVoltageConfigured(void);
 uint16_t getBatteryVoltage(void);


### PR DESCRIPTION
Very first draft: battery compensation on motor output.

Can be enabled by setting vbat_comp_motor_output ON. When enabled will disable battery compensation on PIDs and throttle.

Uses the vbat_comp_throttle_level as compensation level in order to reduce parameters pollution.